### PR TITLE
IDAW-834: Enable passive mode for OSO Haven plugin

### DIFF
--- a/contracts/ibm-digital-asset-haven/frontend/frontend.yml.tftpl
+++ b/contracts/ibm-digital-asset-haven/frontend/frontend.yml.tftpl
@@ -39,7 +39,7 @@ spec:
       ports:
         - containerPort: 4000
           hostPort: 4000
-%{ if tpl.passive_mode }
+%{ if !tpl.passive_mode }
     - name: hsm-forwarder
       image: ${tpl.hsmdriver_image}
       volumeMounts:

--- a/contracts/ibm-digital-asset-haven/frontend/frontend.yml.tftpl
+++ b/contracts/ibm-digital-asset-haven/frontend/frontend.yml.tftpl
@@ -25,6 +25,8 @@ spec:
           value: "frontend"
         - name: BASE_URL
           value: ${tpl.base_url}
+        - name: PASSIVE_MODE
+          value: ${tpl.passive_mode}
     - name: frontend_plugin_proxy
       image: ${tpl.plugin_image}
       command:

--- a/contracts/ibm-digital-asset-haven/frontend/frontend.yml.tftpl
+++ b/contracts/ibm-digital-asset-haven/frontend/frontend.yml.tftpl
@@ -39,6 +39,7 @@ spec:
       ports:
         - containerPort: 4000
           hostPort: 4000
+%{ if tpl.passive_mode }
     - name: hsm-forwarder
       image: ${tpl.hsmdriver_image}
       volumeMounts:
@@ -76,3 +77,4 @@ spec:
         path: ./signing-integrity
         type: FileOrCreate
       name: signing-integrity
+%{ endif }

--- a/contracts/ibm-digital-asset-haven/frontend/user_data_frontend.tf
+++ b/contracts/ibm-digital-asset-haven/frontend/user_data_frontend.tf
@@ -23,6 +23,7 @@ resource "local_file" "frontend_podman_play" {
       proxy_address = var.PROXY_ADDRESS,
       base_url = var.BASE_URL,
       governance_engine_enabled = var.GOVERNANCE_ENGINE_ENABLED,
+      passive_mode = var.PASSIVE_MODE,
     } },
   )
   filename = "frontend/podman-play.yml"

--- a/contracts/ibm-digital-asset-haven/frontend/variables.tf
+++ b/contracts/ibm-digital-asset-haven/frontend/variables.tf
@@ -54,3 +54,9 @@ variable "GOVERNANCE_ENGINE_ENABLED" {
   description = "Enable Governance Engine Configuration"
   default     = false
 }
+
+variable "PASSIVE_MODE" {
+  type        = bool
+  default     = false
+  description = "Passive Mode enablement"
+}

--- a/ibm-digital-asset-haven-plugin/src/plugin/plugin.py
+++ b/ibm-digital-asset-haven-plugin/src/plugin/plugin.py
@@ -87,6 +87,7 @@ class Plugin(PluginProtocol):
 
     def to_oso(self) -> V1_3.DocumentList:
         logger.debug(f"Entering to_oso(): ({self.mode})")
+        is_passive = os.getenv("PASSIVE_MODE")
 
         docs: list[V1_3.Document] = []
         url: str
@@ -94,19 +95,22 @@ class Plugin(PluginProtocol):
         try:
             match self.mode:
                 case "frontend":
-                    operations = get(get_operations_endpoint(FRONTEND_PORT))
-                    for op in operations:
-                        id = op["uuid"]
-                        assert id
-                        if id not in self.frontendknownids:
-                            metadata_value = self.build_metadata(op)
-                            docs.append(V1_3.Document(
-                                id=id,
-                                content=json.dumps(op),
-                                metadata=metadata_value))
-                            self.frontendknownids.append(id)
-                        else:
-                            logger.debug(f"to_oso() ignoring operation handled previoulsy: id={id}")
+                    if is_passive == "false":
+                        operations = get(get_operations_endpoint(FRONTEND_PORT))
+                        for op in operations:
+                            id = op["uuid"]
+                            assert id
+                            if id not in self.frontendknownids:
+                                metadata_value = self.build_metadata(op)
+                                docs.append(V1_3.Document(
+                                    id=id,
+                                    content=json.dumps(op),
+                                    metadata=metadata_value))
+                                self.frontendknownids.append(id)
+                            else:
+                                logger.debug(f"to_oso() ignoring operation handled previoulsy: id={id}")
+                    else:
+                        logger.debug(f"Passive Mode is Set to true")
 
                 case "backend":
                     responses = get(get_completed_endpoint(BACKEND_PORT))
@@ -146,7 +150,7 @@ class Plugin(PluginProtocol):
 
             except Exception as e:
                 logger.error(f"ERROR: could not post document: {doc.id}, Error: {e}")
-                failures += 1
+                failedPosts += 1
                 continue
 
         logger.debug(f"to_isv() returning: {failedPosts=}")


### PR DESCRIPTION
As part of this PR added a new flag to support Passive Mode for IDAH front plugins.
By default the value of Passive Mode is set to false.
And to bring up frontend plugin in Passive mode the value of this variable needs to be set to true before generating frontend workload
When the Passive Mode is enabled then the frontend plugin will not run HSM Signer container image and the documents will not be processed in Passive OSO appliance setup.