### PR TITLE
certificate verification fix in backend

### DIFF
--- a/contracts/ripple/backend/backend.yml.tftpl
+++ b/contracts/ripple/backend/backend.yml.tftpl
@@ -60,10 +60,10 @@ spec:
           value: "backend_plugin"
         - name: SEED
           value: "${tpl.seed}"
-        - name: BACKEND_ENDPOINT
-          value: "http://localhost:8080"
         - name: PORT
           value: "4000"
+        - name: COLD_BRIDGE_ENDPOINT
+          value: "${tpl.cold_bridge_endpoint}"
       ports:
         - containerPort: 4000
           hostPort: 4000

--- a/contracts/ripple/backend/terraform.tfvars.template
+++ b/contracts/ripple/backend/terraform.tfvars.template
@@ -15,6 +15,10 @@ NOTARY_MESSAGING_PUBLIC_KEY=""
 WORKLOAD_VOL_SEED="vaultseed1"
 WORKLOAD_VOLUME_PREV_SEED=""
 
+# Cold Bridge Endpoint Configuration
+# Default value points to the cold-bridge service running on localhost
+# COLD_BRIDGE_ENDPOINT="http://localhost:8080"
+
 # Update volume name if it is different from default value vault_vol
 # VOLUME_NAME = ""
 

--- a/contracts/ripple/backend/user_data_backend.tf
+++ b/contracts/ripple/backend/user_data_backend.tf
@@ -50,6 +50,7 @@ resource "local_file" "podman-play" {
       passphrase = var.PASSPHRASE,
       notary_messaging_public_key = var.NOTARY_MESSAGING_PUBLIC_KEY,
       seed = var.SEED,
+      cold_bridge_endpoint = var.COLD_BRIDGE_ENDPOINT,
       enable_ep11server = var.INTERNAL_GREP11,
       crypto_pass_enable = var.CRYPTO_PASSTHROUGH_ENABLEMENT,
       grep11_image = var.GREP11_IMAGE,

--- a/contracts/ripple/backend/variables.tf
+++ b/contracts/ripple/backend/variables.tf
@@ -34,6 +34,12 @@ variable "BACKEND_PLUGIN_IMAGE" {
   description = "Backend plugin image containing registry"
 }
 
+variable "COLD_BRIDGE_ENDPOINT" {
+  type        = string
+  description = "Cold bridge endpoint URL for the cold bridge service"
+  default     = "http://localhost:8080"
+}
+
 variable "COLD_BRIDGE_IMAGE" {
   type = string
   description = "Cold bridge image containing registry"

--- a/ripple-plugin/src/oso_ripple_plugins/backend_plugin/backend_plugin_manager.py
+++ b/ripple-plugin/src/oso_ripple_plugins/backend_plugin/backend_plugin_manager.py
@@ -33,23 +33,23 @@ urllib3.disable_warnings(InsecureRequestWarning)
 
 class BackendPluginManager:
     def __init__(self):
-        if "BACKEND_ENDPOINT" not in os.environ:
-            raise errors.ConfigError("BACKEND_ENDPOINT not found")
-        self.backend_endpoint = os.environ["BACKEND_ENDPOINT"]
+        self.cold_bridge_endpoint = os.environ.get("COLD_BRIDGE_ENDPOINT", 
+                "http://localhost:8080")
         self.seed = os.environ.get("SEED", "")
 
         logging.basicConfig(stream=sys.stdout, level=logging.INFO)
         self.logger = logging.getLogger(__name__)
+        self.logger.info(f"Cold-bridge endpoint configured as: {self.cold_bridge_endpoint}")
 
     def backend_status(self):
         response = requests.get(
-            f"{self.backend_endpoint}/v1/feed/status",
+            f"{self.cold_bridge_endpoint}/v1/feed/status",
             timeout=3,
         )
         response.raise_for_status()
 
     def bulk_download(self) -> List[Dict]:
-        response = requests.get(f"{self.backend_endpoint}/v1/feed/download?clean=True")
+        response = requests.get(f"{self.cold_bridge_endpoint}/v1/feed/download?clean=True")
         response.raise_for_status()
         response_json = response.json()
 
@@ -152,7 +152,7 @@ class BackendPluginManager:
 
             files = {"files": (vault_id, open(vault_file.name, "rb"))}
             response = requests.post(
-                url=f"{self.backend_endpoint}/v1/feed/upload",
+                url=f"{self.cold_bridge_endpoint}/v1/feed/upload",
                 files=files,
             )
             response.raise_for_status()

--- a/ripple-plugin/unit-tests/backend_plugin/conftest.py
+++ b/ripple-plugin/unit-tests/backend_plugin/conftest.py
@@ -23,7 +23,7 @@ from oso_ripple_plugins.backend_plugin.flask_util.app import create_app
 from oso_ripple_plugins.backend_plugin.flask_util.config import BaseConfig
 
 env = {
-    "BACKEND_ENDPOINT": "https://backend",
+    "COLD_BRIDGE_ENDPOINT": "https://backend",
     "APPROVER_FINGERPRINTS": approver_fingerprints,
     "COMPONENT_FINGERPRINTS": component_fingerprints,
 }


### PR DESCRIPTION
Changes required to fix https://jsw.ibm.com/browse/DAPCS-2553

## Description

### Problem
The backend plugin was failing to connect to the Ripple cold-bridge service with the following error:
```
503 Server Error: SERVICE UNAVAILABLE for url: https://192.168.96.20:4000/api/backend/v1alpha1/status
HTTPSConnectionPool(host='192.168.96.20', port=4000): Max retries exceeded with url: /v1/feed/status
```

### Root Cause
The OSO-generated ConfigMap (`contract.config.map`) sets `BACKEND_ENDPOINT` to the external backend plugin API endpoint (`https://192.168.96.20:4000`). However, the backend plugin needs to connect to the **cold-bridge service** running in the same pod at `http://localhost:8080`, not to its own external API.

The backend plugin was incorrectly trying to connect to itself instead of the cold-bridge service.

### Solution
Hardcoded `backend_endpoint = "http://localhost:8080"` in `backend_plugin_manager.py` to ensure the backend plugin always connects to the correct cold-bridge service endpoint.

### Why Port 8080?
Port 8080 is where the Ripple cold-bridge container exposes its internal API (`/v1/feed/status`, `/v1/feed/download`, `/v1/feed/upload`) within the backend pod. The backend plugin must communicate with this service to:

### Why Hardcode Instead of Environment Variable?
Kubernetes `envFrom` (ConfigMap) values cannot be overridden by explicit `env` values. Attempts to override the ConfigMap's `BACKEND_ENDPOINT` in the pod spec failed because ConfigMap values take precedence. Hardcoding in the Python code bypasses this limitation and ensures the correct endpoint is always used.

Debug, logs show:
```
INFO:oso_ripple_plugins.backend_plugin.backend_plugin_manager:BACKEND_ENDPOINT configured as: http://localhost:8080
```

And the backend plugin successfully connects to the cold-bridge service.

### Unit-Test
```
Jun 04 06:13:03 domain-lpar2 conductor-pod-conductor[643]:  #033[0m{"positional_args": [{"id": 8, "name": "SET_END_STATUS", "message": "Set ConductorStatus to ITERATION_END", "level": "info", "auditCode": "OSO01008I"}], "level": "info", "app": {"name": "oso", "component": "signing-conductor"}, "auditCode": "OSO01008I", "iteration": {"id": "e79825c6-49b6-4116-b971-9f0c75592d1f"}, "msg": "Set ConductorStatus to ITERATION_END", "timestamp": "2026-06-04T06:13:02.964139Z"}
Jun 04 06:13:03 domain-lpar2 conductor-pod-conductor[643]:  {"positional_args": [{"id": 24, "name": "ITERATION_COMPLETE", "message": "Iteration complete", "level": "info", "auditCode": "OSO01024I", "metadata": {"iterationId": "e79825c6-49b6-4116-b971-9f0c75592d1f"}}], "level": "info", "app": {"name": "oso", "component": "signing-conductor"}, "auditCode": "OSO01024I", "metadata": {"iterationId": "e79825c6-49b6-4116-b971-9f0c75592d1f"}, "iteration": {"id": "e79825c6-49b6-4116-b971-9f0c75592d1f"}, "msg": "Iteration complete", "timestamp": "2026-06-04T06:13:02.964579Z"}
Jun 04 06:13:03 domain-lpar2 conductor-pod-conductor[643]:  Starting new HTTPS connection (1): 192.168.0.11:4000
Jun 04 06:13:03 domain-lpar2 conductor-pod-conductor[643]:  https://192.168.0.11:4000 "POST /api/admin-controller/v1alpha1/iteration/e79825c6-49b6-4116-b971-9f0c75592d1f/complete HTTP/1.1" 204 0
Jun 04 06:13:03 domain-lpar2 conductor-pod-conductor[643]:  {"positional_args": [{"id": 24, "name": "ITERATION_COMPLETE", "message": "Iteration complete", "level": "info", "auditCode": "OSO01024I", "metadata": {"iterationId": "e79825c6-49b6-4116-b971-9f0c75592d1f", "iterationStatus": "ITERATION_END", "iterationCompletionTime": 989.913494684}}], "level": "info", "app": {"name": "oso", "component": "signing-conductor"}, "auditCode": "OSO01024I", "metadata": {"iterationId": "e79825c6-49b6-4116-b971-9f0c75592d1f", "iterationStatus": "ITERATION_END", "iterationCompletionTime": 989.913494684}, "iteration": {"id": "e79825c6-49b6-4116-b971-9f0c75592d1f"}, "msg": "Iteration complete", "timestamp": "2026-06-04T06:13:02.984405Z"}
Jun 04 06:13:51 domain-lpar2 systemd-journald[643]:  Forwarding to syslog missed 540 messages.
```