### PR TITLE
Implement batch upload support for Ripple plugin

### DIFF
--- a/contracts/ripple/frontend_plugin/frontend_plugin.yml.tftpl
+++ b/contracts/ripple/frontend_plugin/frontend_plugin.yml.tftpl
@@ -29,6 +29,8 @@ spec:
           value: "${tpl.SEED}"
         - name: TOKEN_EXP
           value: "${tpl.TOKEN_EXP}"
+        - name: BATCH_UPLOAD_SIZE
+          value: "${tpl.BATCH_UPLOAD_SIZE}"
       ports:
         - containerPort: 4000 
           hostPort: 4000

--- a/contracts/ripple/frontend_plugin/terraform.tfvars.template
+++ b/contracts/ripple/frontend_plugin/terraform.tfvars.template
@@ -6,3 +6,6 @@ HMZ_AUTH_HOSTNAME=""
 HMZ_API_HOSTNAME=""
 VAULT_ID=""
 SK=""
+
+# Frontend Plugin Configuration
+BATCH_UPLOAD_SIZE=20

--- a/contracts/ripple/frontend_plugin/user_data_frontend_plugin.tf
+++ b/contracts/ripple/frontend_plugin/user_data_frontend_plugin.tf
@@ -24,7 +24,8 @@ resource "local_file" "frontend_plugin_podman_play" {
       HMZ_API_HOSTNAME  = var.HMZ_API_HOSTNAME,
       ROOTCERT          = var.ROOTCERT,
       SEED              = var.SEED,
-      TOKEN_EXP         = var.TOKEN_EXP
+      TOKEN_EXP         = var.TOKEN_EXP,
+      BATCH_UPLOAD_SIZE = var.BATCH_UPLOAD_SIZE
     } },
   )
   filename        = "frontend_plugin/play.yml"

--- a/contracts/ripple/frontend_plugin/variables.tf
+++ b/contracts/ripple/frontend_plugin/variables.tf
@@ -69,3 +69,14 @@ variable "TOKEN_EXP" {
   description = "Ripple configured bearer token expiration (#h#m#s format)"
   default = "4h0m0s"
 }
+
+variable "BATCH_UPLOAD_SIZE" {
+  type        = number
+  description = "Number of documents per batch during bulk upload"
+  default     = 20
+
+  validation {
+    condition     = var.BATCH_UPLOAD_SIZE > 0
+    error_message = "BATCH_UPLOAD_SIZE must be a positive integer."
+  }
+}

--- a/ripple-plugin/src/oso_ripple_plugins/frontend_plugin/frontend_plugin_manager.py
+++ b/ripple-plugin/src/oso_ripple_plugins/frontend_plugin/frontend_plugin_manager.py
@@ -233,10 +233,15 @@ class FrontendPluginManager:
         return documents
 
     def bulk_upload(self, documents):
+        BATCH_SIZE = 20
+
         vaults = []
         transactions = []
         accounts = []
         manifests = []
+        doc_count = 0
+        batch_num = 1
+        failed_batches = []  # track batches that failed to send
 
         self.logger.info("Saving documents for bulk upload")
         for document in documents:
@@ -254,13 +259,60 @@ class FrontendPluginManager:
                 manifests.extend(contents.get("manifests", []))
                 vaults.extend(contents.get("vaults", []))
 
+                doc_count += 1
+
                 self.logger.info(
                     f"Successfully saved document {document_id} for bulk upload"
                 )
+
             except Exception as e:
+                # Only parsing/decryption failures land here
+                # a bad document is skipped, batch state is untouched.
                 self.logger.exception(e)
                 continue
 
+            # Flush every BATCH_SIZE documents
+            if doc_count >= BATCH_SIZE:
+                self.logger.info(f"Flushing batch {batch_num} ({doc_count} documents)")
+                self._flush_batch(
+                    batch_num, transactions, accounts, manifests, vaults, failed_batches
+                )
+                vaults, transactions, accounts, manifests, doc_count = [], [], [], [], 0
+                batch_num += 1
+
+
+        # Send any remaining documents
+        if doc_count > 0:
+            self.logger.info(f"Flushing final batch {batch_num} ({doc_count} documents)")
+            self._flush_batch(
+                batch_num, transactions, accounts, manifests, vaults, failed_batches
+            )
+
+        if failed_batches:
+            self.logger.error(
+                f"Bulk upload finished with {len(failed_batches)} failed batch(es): "
+                f"{failed_batches}"
+            )
+        else:
+            self.logger.info("Bulk upload finished successfully")
+
+    def _flush_batch(self, batch_num, transactions, accounts, manifests, vaults, failed_batches):
+        """Send one batch; on failure, log it, record it, and let the run continue."""
+        try:
+            self._send_batch(transactions, accounts, manifests, vaults)
+        except Exception as e:
+            self.logger.exception(f"Batch {batch_num} failed to upload: {e}")
+            failed_batches.append(
+                {
+                    "batch_num": batch_num,
+                    "accounts": accounts,
+                    "transactions": transactions,
+                    "manifests": manifests,
+                    "vaults": vaults,
+                }
+            )
+
+    def _send_batch(self, transactions, accounts, manifests, vaults):
         content = {
             "accounts": accounts,
             "transactions": transactions,
@@ -268,25 +320,32 @@ class FrontendPluginManager:
             "vaults": vaults,
         }
 
-        self.logger.info("Performing bulk upload to frontend")
+        self.logger.info(
+            f"Performing bulk upload to frontend "
+            f"(accounts={len(accounts)}, transactions={len(transactions)}, "
+            f"manifests={len(manifests)}, vaults={len(vaults)})"
+        )
+
         token = self.get_token()
+        vault_file_path = None
         try:
             with tempfile.NamedTemporaryFile(mode="w", delete=False) as vault_file:
                 json.dump(content, vault_file)
+                vault_file_path = vault_file.name
 
-            files = {"files": open(vault_file.name, "rb")}
-            response = requests.post(
-                url=f"https://{self.hmz_api_hostname}/v1/vaults/operations/signed",
-                headers={"Authorization": "Bearer " + token},
-                files=files,
-                verify=self.verify,
-            )
+            with open(vault_file_path, "rb") as f:
+                response = requests.post(
+                    url=f"https://{self.hmz_api_hostname}/v1/vaults/operations/signed",
+                    headers={"Authorization": "Bearer " + token},
+                    files={"files": f},
+                    verify=self.verify,
+                )
             response.raise_for_status()
         except Exception as e:
             raise e
         finally:
-            os.remove(vault_file.name)
-        self.logger.info("Bulk upload finished successfully")
+            if vault_file_path:
+                os.remove(vault_file_path)
 
     def backend_status(self):
         pass

--- a/ripple-plugin/src/oso_ripple_plugins/frontend_plugin/frontend_plugin_manager.py
+++ b/ripple-plugin/src/oso_ripple_plugins/frontend_plugin/frontend_plugin_manager.py
@@ -74,6 +74,14 @@ class FrontendPluginManager:
         if self.token_exp_in_secs == 0:
             raise errors.ConfigError("TOKEN_EXP format is invalid")
 
+        try:
+            self.batch_size = int(os.environ.get("BATCH_UPLOAD_SIZE", 20))
+        except ValueError:
+            raise errors.ConfigError("BATCH_UPLOAD_SIZE must be a valid integer")
+
+        if self.batch_size <= 0:
+            raise errors.ConfigError("BATCH_UPLOAD_SIZE must be a positive integer")
+
         logging.basicConfig(stream=sys.stdout, level=logging.INFO)
         self.logger = logging.getLogger(__name__)
 
@@ -233,8 +241,6 @@ class FrontendPluginManager:
         return documents
 
     def bulk_upload(self, documents):
-        BATCH_SIZE = 20
-
         vaults = []
         transactions = []
         accounts = []
@@ -271,8 +277,8 @@ class FrontendPluginManager:
                 self.logger.exception(e)
                 continue
 
-            # Flush every BATCH_SIZE documents
-            if doc_count >= BATCH_SIZE:
+            # Flush every batch_size documents
+            if doc_count >= self.batch_size:
                 self.logger.info(f"Flushing batch {batch_num} ({doc_count} documents)")
                 self._flush_batch(
                     batch_num, transactions, accounts, manifests, vaults, failed_batches

--- a/ripple-plugin/unit-tests/frontend_plugin/conftest.py
+++ b/ripple-plugin/unit-tests/frontend_plugin/conftest.py
@@ -94,3 +94,9 @@ def app(set_env, tmpdir, mocker):
 def client(app):
     """A test client for the app."""
     return app.test_client()
+
+
+@pytest.fixture(scope="function")
+def batch_upload_size(request, monkeypatch):
+    monkeypatch.setenv("BATCH_UPLOAD_SIZE", str(request.param))
+    yield request.param

--- a/ripple-plugin/unit-tests/frontend_plugin/test_frontend_integration.py
+++ b/ripple-plugin/unit-tests/frontend_plugin/test_frontend_integration.py
@@ -591,3 +591,61 @@ def test_docs_upload_continues_after_batch_failure(client):
             req for req in m.request_history if req.url == signed_url
         ]
         assert len(signed_calls) == 2
+
+
+def test_docs_upload_respects_custom_batch_size(client, monkeypatch):
+    """With BATCH_UPLOAD_SIZE=5, 12 documents should split into 5 + 5 + 2."""
+    monkeypatch.setenv("BATCH_UPLOAD_SIZE", "5")
+
+    documents = [
+        {
+            "id": f"test_account_id_{i}",
+            "content": json.dumps(
+                {
+                    "vaultId": "test_vault_id",
+                    "accounts": [{"accountId": f"test_account_id_{i}"}],
+                    "transactions": [],
+                    "manifests": [],
+                }
+            ),
+            "metadata": "",
+        }
+        for i in range(12)
+    ]
+    payload = {"documents": documents, "count": 12}
+
+    token_url = "https://hmz_auth_hostname/token"
+    signed_url = "https://hmz_api_hostname/v1/vaults/operations/signed"
+
+    with requests_mock.mock() as m:
+        m.post(token_url, json={"access_token": "test_token"}, status_code=200)
+        m.post(
+            signed_url,
+            json={"accounts": [], "transactions": [], "manifests": [], "vaults": []},
+            status_code=200,
+        )
+
+        response = client.post(
+            "api/frontend/v1alpha1/documents",
+            headers={
+                "X-SSL-CERT": component_cert,
+                "X-SSL-CLIENT-VERIFY": "SUCCESS",
+            },
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 204
+
+        signed_calls = [req for req in m.request_history if req.url == signed_url]
+        assert len(signed_calls) == 3  # 5 + 5 + 2
+
+        batch_sizes = []
+        for call in signed_calls:
+            parts = decoder.MultipartDecoder(
+                call.body, call.headers["Content-Type"], "utf-8"
+            ).parts
+            accounts = json.loads(parts[0].text)["accounts"]
+            batch_sizes.append(len(accounts))
+
+        assert batch_sizes == [5, 5, 2]

--- a/ripple-plugin/unit-tests/frontend_plugin/test_frontend_integration.py
+++ b/ripple-plugin/unit-tests/frontend_plugin/test_frontend_integration.py
@@ -593,10 +593,9 @@ def test_docs_upload_continues_after_batch_failure(client):
         assert len(signed_calls) == 2
 
 
-def test_docs_upload_respects_custom_batch_size(client, monkeypatch):
+@pytest.mark.parametrize("batch_upload_size", [5], indirect=True)
+def test_docs_upload_respects_custom_batch_size(batch_upload_size, client):
     """With BATCH_UPLOAD_SIZE=5, 12 documents should split into 5 + 5 + 2."""
-    monkeypatch.setenv("BATCH_UPLOAD_SIZE", "5")
-
     documents = [
         {
             "id": f"test_account_id_{i}",

--- a/ripple-plugin/unit-tests/frontend_plugin/test_frontend_integration.py
+++ b/ripple-plugin/unit-tests/frontend_plugin/test_frontend_integration.py
@@ -462,3 +462,132 @@ def test_encrypted_upload(seed, client):
             "manifests": [{"manifestId": "test_manifest_id"}],
             "vaults": [],
         }
+
+
+def test_docs_upload_multiple_batches(client):
+    """25 documents should be split into two upload requests: 20 + 5."""
+    documents = [
+        {
+            "id": f"test_account_id_{i}",
+            "content": json.dumps(
+                {
+                    "vaultId": "test_vault_id",
+                    "accounts": [{"accountId": f"test_account_id_{i}"}],
+                    "transactions": [],
+                    "manifests": [],
+                }
+            ),
+            "metadata": "",
+        }
+        for i in range(25)
+    ]
+    payload = {"documents": documents, "count": 25}
+
+    token_url = "https://hmz_auth_hostname/token"
+    signed_url = "https://hmz_api_hostname/v1/vaults/operations/signed"
+
+    with requests_mock.mock() as m:
+        m.post(token_url, json={"access_token": "test_token"}, status_code=200)
+        m.post(
+            signed_url,
+            json={"accounts": [], "transactions": [], "manifests": [], "vaults": []},
+            status_code=200,
+        )
+
+        response = client.post(
+            "api/frontend/v1alpha1/documents",
+            headers={
+                "X-SSL-CERT": component_cert,
+                "X-SSL-CLIENT-VERIFY": "SUCCESS",
+            },
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 204
+
+        # Two batches (20 + 5) => two calls to the signed upload endpoint
+        signed_calls = [
+            req for req in m.request_history if req.url == signed_url
+        ]
+        assert len(signed_calls) == 2
+
+        first_batch = decoder.MultipartDecoder(
+            signed_calls[0].body, signed_calls[0].headers["Content-Type"], "utf-8"
+        ).parts
+        second_batch = decoder.MultipartDecoder(
+            signed_calls[1].body, signed_calls[1].headers["Content-Type"], "utf-8"
+        ).parts
+
+        first_accounts = json.loads(first_batch[0].text)["accounts"]
+        second_accounts = json.loads(second_batch[0].text)["accounts"]
+
+        assert len(first_accounts) == 20
+        assert len(second_accounts) == 5
+        # No overlap / no drops across the batch boundary
+        all_ids = {a["accountId"] for a in first_accounts} | {
+            a["accountId"] for a in second_accounts
+        }
+        assert all_ids == {f"test_account_id_{i}" for i in range(25)}
+
+
+def test_docs_upload_continues_after_batch_failure(client):
+    """If one batch's upload fails, later batches should still be sent
+    (i.e. the whole run should not abort on a single batch failure)."""
+    documents = [
+        {
+            "id": f"test_account_id_{i}",
+            "content": json.dumps(
+                {
+                    "vaultId": "test_vault_id",
+                    "accounts": [{"accountId": f"test_account_id_{i}"}],
+                    "transactions": [],
+                    "manifests": [],
+                }
+            ),
+            "metadata": "",
+        }
+        for i in range(25)  # 2 batches: 20 + 5
+    ]
+    payload = {"documents": documents, "count": 25}
+
+    token_url = "https://hmz_auth_hostname/token"
+    signed_url = "https://hmz_api_hostname/v1/vaults/operations/signed"
+
+    with requests_mock.mock() as m:
+        m.post(token_url, json={"access_token": "test_token"}, status_code=200)
+        # First batch fails (500), second batch succeeds
+        m.post(
+            signed_url,
+            [
+                {"status_code": 500},
+                {
+                    "json": {
+                        "accounts": [],
+                        "transactions": [],
+                        "manifests": [],
+                        "vaults": [],
+                    },
+                    "status_code": 200,
+                },
+            ],
+        )
+
+        response = client.post(
+            "api/frontend/v1alpha1/documents",
+            headers={
+                "X-SSL-CERT": component_cert,
+                "X-SSL-CLIENT-VERIFY": "SUCCESS",
+            },
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        # The run should complete (not raise/abort) despite the first
+        # batch failing — both batches should have been attempted.
+        assert response.status_code == 204
+
+        signed_calls = [
+            req for req in m.request_history if req.url == signed_url
+        ]
+        assert len(signed_calls) == 2

--- a/ripple-plugin/unit-tests/frontend_plugin/test_frontend_manager.py
+++ b/ripple-plugin/unit-tests/frontend_plugin/test_frontend_manager.py
@@ -20,7 +20,7 @@ import uuid
 import pytest
 import requests_mock
 
-from oso_ripple_plugins.common import utils
+from oso_ripple_plugins.common import utils, errors
 from oso_ripple_plugins.frontend_plugin.frontend_plugin_manager import (
     FrontendPluginManager,
 )
@@ -90,3 +90,18 @@ def test_parse_wait_time(set_env, monkeypatch):
     for time_check in times:
         monkeypatch.setenv("TOKEN_EXP", time_check[0])
         assert time_check[1] == utils.parse_wait_time(os.environ.get("TOKEN_EXP"))
+
+
+def test_invalid_batch_upload_size_raises_config_error(monkeypatch):
+    """A non-integer BATCH_UPLOAD_SIZE should raise ConfigError, not a bare ValueError."""
+    monkeypatch.setenv("BATCH_UPLOAD_SIZE", "not-a-number")
+    # adjust required env vars below to match your test setup / conftest fixtures
+    with pytest.raises(errors.ConfigError, match="BATCH_UPLOAD_SIZE must be a valid integer"):
+        FrontendPluginManager()
+
+
+def test_zero_batch_upload_size_raises_config_error(monkeypatch):
+    """A zero or negative BATCH_UPLOAD_SIZE should raise ConfigError."""
+    monkeypatch.setenv("BATCH_UPLOAD_SIZE", "0")
+    with pytest.raises(errors.ConfigError, match="BATCH_UPLOAD_SIZE must be a positive integer"):
+        FrontendPluginManager()


### PR DESCRIPTION
**bulk_upload** previously sent all documents to the frontend API in a single request. This change splits uploads into batches of 20 documents, so a single upload call no longer scales unbounded with the size of the document set, and a failure in one batch doesn't abort the entire run.

